### PR TITLE
Optimize wallet interaction

### DIFF
--- a/dapp/src/tmTransferSpore.ts
+++ b/dapp/src/tmTransferSpore.ts
@@ -34,7 +34,7 @@ async function main() {
 
     let { txSkeleton } = await transferSpore({
         outPoint: {
-            txHash: '0xdf3bdc04ca7bf89b5bc146d01318b6405170c776e91282b181d42cb3fd746022',
+            txHash: '0xab2a0f4073278bfdbf5e8b2ab2f7a984f5360452c7ec81b7c28ecc5758f43ec4',
             index: '0x0',
         },
         toLock: tmAccounts.bob.lock,


### PR DESCRIPTION
Now the wallet will display Dapp related information and wait for the user to confirm the signature.

```
Dapp name: spore
Dapp url: https://a-simple-demo.spore.pro
Dapp action: {
    "type": "Transfer",
    "value": {
        "nftID": "0x6ce030170980304f0e0121a69c8045bef87dd0ce647acb96ba4a630fd4d8ee32",
        "to": {
            "type": "Script",
            "value": {
                "codeHash": "0xbce10030b8dea1ada7efa45ea6fa981bb59ce61d53cd9e34815641a80667501a",
                "hashType": "data1",
                "args": "0xa3c778981c19e1dcc611fb2132dcdaac075a5064"
            }
        }
    }
}
Sign and send the message? [Y]es, [N]o
n
```