### PR TITLE
Update message digest

### DIFF
--- a/ckb-transaction-cobuild/src/lib.rs
+++ b/ckb-transaction-cobuild/src/lib.rs
@@ -132,11 +132,11 @@ pub fn generate_skeleton_hash() -> Result<[u8; 32], Error> {
     Ok(output)
 }
 
-pub fn generate_message_digest(skeleton_hash: &[u8; 32], message: &[u8]) -> [u8; 32] {
+pub fn generate_message_digest(message: &[u8], skeleton_hash: &[u8; 32]) -> [u8; 32] {
     let mut hasher = new_blake2b();
-    hasher.update(&skeleton_hash[..]);
     hasher.update(&(message.len() as u64).to_le_bytes());
     hasher.update(message);
+    hasher.update(&skeleton_hash[..]);
     let mut output = [0u8; 32];
     hasher.finalize(&mut output);
     return output;
@@ -181,6 +181,6 @@ pub fn parse_message() -> Result<([u8; 32], Vec<u8>), Error> {
         }
     };
     let skeleton_hash = generate_skeleton_hash()?;
-    let message_digest = generate_message_digest(&skeleton_hash, message.as_slice());
+    let message_digest = generate_message_digest(message.as_slice(), &skeleton_hash);
     Ok((message_digest, lock.raw_data().into()))
 }

--- a/dapp/src/tmBuild.ts
+++ b/dapp/src/tmBuild.ts
@@ -222,10 +222,10 @@ export function generateSkeletonHash(tx: UnpackResult<typeof blockchain.Transact
     return ckbHash(data)
 }
 
-export function generateFinalHash(skeletonHash: HexString, typedMessage: HexString): HexString {
+export function generateFinalHash(typedMessage: HexString, skeletonHash: HexString): HexString {
     let data = ''
-    data += skeletonHash
     data += bytes.hexify(Uint64.pack(typedMessage.length / 2 - 1)).slice(2)
     data += typedMessage.slice(2)
+    data += skeletonHash
     return ckbHash(data)
 }

--- a/tests/src/tx.rs
+++ b/tests/src/tx.rs
@@ -315,9 +315,9 @@ pub fn sign_tx(witnesses: &mut MessageWitnesses, tx: TransactionView) -> Transac
         }
 
         let mut hasher = new_blake2b();
-        hasher.update(&skeleton_hash);
         hasher.update(&msg.len().to_le_bytes());
         hasher.update(&msg);
+        hasher.update(&skeleton_hash);
 
         let mut message_digest = [0u8; 32];
         hasher.finalize(&mut message_digest);


### PR DESCRIPTION
According to the spec, message digest is changed from "skeleton hash" + "message" to "message" + "skeleton hash".
