### PR TITLE
Add missing ckb-std feature ckb-types

### DIFF
--- a/ckb-transaction-cobuild/Cargo.toml
+++ b/ckb-transaction-cobuild/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 blake2b-ref = "0.3.1"
-ckb-std = { version = "0.14.3", default-features = false }
+ckb-std = { version = "0.14.3", default-features = false,  features = ["ckb-types"] }
 molecule = { version = "0.7.5", default-features = false }
 ckb-gen-types = { version = "0.111.0", default-features = false }

--- a/ckb-transaction-cobuild/Cargo.toml
+++ b/ckb-transaction-cobuild/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 blake2b-ref = "0.3.1"
-ckb-std = { version = "0.14.3", default-features = false,  features = ["ckb-types"] }
+ckb-std = { version = "0.14.3", default-features = false,  features = ["allocator", "ckb-types"] }
 molecule = { version = "0.7.5", default-features = false }
 ckb-gen-types = { version = "0.111.0", default-features = false }


### PR DESCRIPTION
The lib ckb-transaction-cobuild depends on ckb-std features allocator and ckb-types but it does not declare it itself.

The tests and contract building works because they enable all default features in `ckb-std`, and cargo will use the merged features set for the same version of a dependency.